### PR TITLE
Improvements to SiblingContainer

### DIFF
--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -765,6 +765,35 @@ public:
     buffers_initialized_ = initialized;
   }
 
+  /**
+   * Return the number of thread siblings in SiblingContainer.
+   *
+   * This method is meaningful only for SiblingContainer, for which it
+   * returns the number of siblings in the container.
+   * For all other models (including Subnet), it returns 0, which is not
+   * wrong. By defining the method in this way, we avoid many dynamic casts.
+   */
+  virtual size_t
+  num_thread_siblings() const
+  {
+    return 0;
+  }
+
+  /**
+   * Return the specified member of a SiblingContainer.
+   *
+   * This method is meaningful only for SiblingContainer, for which it
+   * returns the pointer to the indexed node in the container.
+   * For all other models (including Subnet), it returns a null pointer
+   * and throws and assertion.By defining the method in this way, we avoid
+   * many dynamic casts.
+   */
+  virtual Node* get_thread_sibling( index ) const
+  {
+    assert( false );
+    return 0;
+  }
+
 private:
   void set_lid_( index );      //!< Set local id, relative to the parent subnet
   void set_parent_( Subnet* ); //!< Set pointer to parent subnet.
@@ -781,44 +810,6 @@ private:
   virtual DictionaryDatum get_status_dict_();
 
 protected:
-  /**
-   * Return the number of thread siblings in SiblingContainer.
-   *
-   * This method is meaningful only for SiblingContainer, for which it
-   * returns the number of siblings in the container.
-   * For all other models (including Subnet), it returns 0, which is not
-   * wrong. By defining the method in this way, we avoid many dynamic casts.
-   */
-  virtual size_t
-  num_thread_siblings_() const
-  {
-    return 0;
-  }
-
-  /**
-   * Return the specified member of a SiblingContainer.
-   *
-   * This method is meaningful only for SiblingContainer, for which it
-   * returns the pointer to the indexed node in the container.
-   * For all other models (including Subnet), it returns a null pointer
-   * and throws and assertion.By defining the method in this way, we avoid
-   * many dynamic casts.
-   */
-  virtual Node* get_thread_sibling_( index ) const
-  {
-    assert( false );
-    return 0;
-  }
-
-  /**
-   * Return specified member of a SiblingContainer, with access control.
-   */
-  virtual Node* get_thread_sibling_safe_( index ) const
-  {
-    assert( false );
-    return 0;
-  }
-
   /**
    * Private function to initialize the state of a node to model defaults.
    * This function, which must be overloaded by all derived classes, provides

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -115,7 +115,7 @@ NodeManager::initialize()
   }
 
   current_ = root_ =
-    static_cast< Subnet* >( ( *root_container ).get_thread_sibling_( 0 ) );
+    static_cast< Subnet* >( ( *root_container ).get_thread_sibling( 0 ) );
 
   /* END of code adding the root subnet. */
 
@@ -150,7 +150,7 @@ NodeManager::reinit_nodes()
   {
     Node* node = local_nodes_.get_node_by_index( n );
     assert( node != 0 );
-    if ( node->num_thread_siblings_() == 0 ) // not a SiblingContainer
+    if ( node->num_thread_siblings() == 0 ) // not a SiblingContainer
     {
       node->init_state();
       node->set_buffers_initialized( false );
@@ -212,9 +212,9 @@ index NodeManager::add_node( index mod, long n ) // no_p
   SiblingContainer* subnet_container =
     dynamic_cast< SiblingContainer* >( subnet_node );
   assert( subnet_container != 0 );
-  assert( subnet_container->num_thread_siblings_()
+  assert( subnet_container->num_thread_siblings()
     == static_cast< size_t >( n_threads ) );
-  assert( subnet_container->get_thread_sibling_( 0 ) == current_ );
+  assert( subnet_container->get_thread_sibling( 0 ) == current_ );
 
   if ( max_gid > local_nodes_.max_size() || max_gid < min_gid )
   {
@@ -357,7 +357,7 @@ index NodeManager::add_node( index mod, long n ) // no_p
     {
       model->reserve_additional( t, n );
       siblingcontainer_model_->reserve_additional( t, container_per_thread );
-      static_cast< Subnet* >( subnet_container->get_thread_sibling_( t ) )
+      static_cast< Subnet* >( subnet_container->get_thread_sibling( t ) )
         ->reserve( n );
     }
 
@@ -395,7 +395,7 @@ index NodeManager::add_node( index mod, long n ) // no_p
         container->push_back( newnode );
 
         // Register instance with per-thread instance of enclosing subnet.
-        static_cast< Subnet* >( subnet_container->get_thread_sibling_( t ) )
+        static_cast< Subnet* >( subnet_container->get_thread_sibling( t ) )
           ->add_node( newnode );
       }
     }
@@ -507,20 +507,20 @@ Node* NodeManager::get_node( index n, thread thr ) // no_p
     return kernel().model_manager.get_proxy_node( thr, n );
   }
 
-  if ( node->num_thread_siblings_() == 0 )
+  if ( node->num_thread_siblings() == 0 )
     return node; // plain node
 
-  if ( thr < 0 || thr >= static_cast< thread >( node->num_thread_siblings_() ) )
+  if ( thr < 0 || thr >= static_cast< thread >( node->num_thread_siblings() ) )
     throw UnknownNode();
 
-  return node->get_thread_sibling_( thr );
+  return node->get_thread_sibling( thr );
 }
 
 const SiblingContainer*
 NodeManager::get_thread_siblings( index n ) const
 {
   Node* node = local_nodes_.get_node_by_gid( n );
-  if ( node->num_thread_siblings_() == 0 )
+  if ( node->num_thread_siblings() == 0 )
     throw NoThreadSiblingsAvailable( n );
   const SiblingContainer* siblings = dynamic_cast< SiblingContainer* >( node );
   assert( siblings != 0 );
@@ -574,7 +574,7 @@ NodeManager::ensure_valid_thread_local_ids()
           Node* node = local_nodes_.get_node_by_index( idx );
           if ( !node->is_subnet()
             && ( static_cast< index >( node->get_thread() ) == t
-                 || node->num_thread_siblings_() > 0 ) )
+                 || node->num_thread_siblings() > 0 ) )
           {
             num_thread_local_nodes++;
             if ( node->node_uses_wfr() )
@@ -595,11 +595,11 @@ NodeManager::ensure_valid_thread_local_ids()
           // If a node has thread siblings, it is a sibling container, and we
           // need to add the replica for the current thread. Otherwise, we have
           // a normal node, which is added only on the thread it belongs to.
-          if ( node->num_thread_siblings_() > 0 )
+          if ( node->num_thread_siblings() > 0 )
           {
-            node->get_thread_sibling_( t )->set_thread_lid(
+            node->get_thread_sibling( t )->set_thread_lid(
               nodes_vec_[ t ].size() );
-            nodes_vec_[ t ].push_back( node->get_thread_sibling_( t ) );
+            nodes_vec_[ t ].push_back( node->get_thread_sibling( t ) );
           }
           else if ( static_cast< index >( node->get_thread() ) == t )
           {
@@ -641,8 +641,8 @@ NodeManager::destruct_nodes_()
   {
     Node* node = local_nodes_.get_node_by_index( n );
     assert( node != 0 );
-    for ( size_t t = 0; t < node->num_thread_siblings_(); ++t )
-      node->get_thread_sibling_( t )->~Node();
+    for ( size_t t = 0; t < node->num_thread_siblings(); ++t )
+      node->get_thread_sibling( t )->~Node();
     node->~Node();
   }
 
@@ -766,9 +766,9 @@ NodeManager::finalize_nodes()
       Node* node = local_nodes_.get_node_by_index( idx );
       if ( node != 0 )
       {
-        if ( node->num_thread_siblings_() > 0 )
+        if ( node->num_thread_siblings() > 0 )
         {
-          node->get_thread_sibling_( t )->finalize();
+          node->get_thread_sibling( t )->finalize();
         }
         else
         {
@@ -805,15 +805,15 @@ NodeManager::set_status( index gid, const DictionaryDatum& d )
     if ( target != 0 )
     {
       // node is local
-      if ( target->num_thread_siblings_() == 0 )
+      if ( target->num_thread_siblings() == 0 )
         set_status_single_node_( *target, d );
       else
-        for ( size_t t = 0; t < target->num_thread_siblings_(); ++t )
+        for ( size_t t = 0; t < target->num_thread_siblings(); ++t )
         {
           // non-root container for devices without proxies and subnets
           // we iterate over all threads
-          assert( target->get_thread_sibling_( t ) != 0 );
-          set_status_single_node_( *( target->get_thread_sibling_( t ) ), d );
+          assert( target->get_thread_sibling( t ) != 0 );
+          set_status_single_node_( *( target->get_thread_sibling( t ) ), d );
         }
     }
     return;
@@ -850,14 +850,13 @@ NodeManager::set_status( const DictionaryDatum& d )
     Node* target = local_nodes_.get_node_by_gid( 0 );
     assert( target != 0 );
 
-    for ( size_t t = 0; t < target->num_thread_siblings_(); ++t )
+    for ( size_t t = 0; t < target->num_thread_siblings(); ++t )
     {
       // Root container for per-thread subnets. We must prevent clearing of
       // access flags before each compound's properties are set by passing false
       // as last arg we iterate over all threads
-      assert( target->get_thread_sibling_( t ) != 0 );
-      set_status_single_node_(
-        *( target->get_thread_sibling_( t ) ), d, false );
+      assert( target->get_thread_sibling( t ) != 0 );
+      set_status_single_node_( *( target->get_thread_sibling( t ) ), d, false );
     }
   }
 }
@@ -882,7 +881,7 @@ NodeManager::reset_nodes_state()
   {
     Node* node = local_nodes_.get_node_by_index( n );
     assert( node != 0 );
-    if ( node->num_thread_siblings_() == 0 ) // not a SiblingContainer
+    if ( node->num_thread_siblings() == 0 ) // not a SiblingContainer
     {
       node->init_state();
       node->set_buffers_initialized( false );

--- a/nestkernel/sibling_container.cpp
+++ b/nestkernel/sibling_container.cpp
@@ -50,15 +50,3 @@ nest::SiblingContainer::SiblingContainer( const SiblingContainer& c )
   , nodes_( c.nodes_ )
 {
 }
-
-nest::Node*
-nest::SiblingContainer::get_thread_sibling_safe_( index i ) const
-{
-  return nodes_.at( i ); // with range check
-}
-
-nest::Node*
-nest::SiblingContainer::get_thread_sibling_( index i ) const
-{
-  return nodes_[ i ]; // without range check
-}

--- a/nestkernel/sibling_container.h
+++ b/nestkernel/sibling_container.h
@@ -45,9 +45,6 @@ namespace nest
  */
 class SiblingContainer : public Node
 {
-  friend class NodeManager;
-  friend class Subnet;
-
 public:
   SiblingContainer();
 
@@ -97,10 +94,10 @@ public:
    */
   std::vector< Node* >::const_iterator end() const;
 
+  size_t num_thread_siblings() const;
+  Node* get_thread_sibling( index ) const;
+
 protected:
-  size_t num_thread_siblings_() const;
-  Node* get_thread_sibling_( index ) const;
-  Node* get_thread_sibling_safe_( index ) const;
   void
   init_node_( const Node& )
   {
@@ -171,7 +168,7 @@ SiblingContainer::empty() const
 }
 
 inline size_t
-SiblingContainer::num_thread_siblings_() const
+SiblingContainer::num_thread_siblings() const
 {
   return nodes_.size();
 }
@@ -192,6 +189,12 @@ inline bool
 SiblingContainer::is_subnet() const
 {
   return empty() ? false : nodes_[ 0 ]->is_subnet();
+}
+
+inline Node*
+SiblingContainer::get_thread_sibling( index i ) const
+{
+  return nodes_[ i ]; // without range check
 }
 
 } // namespace


### PR DESCRIPTION
@weidel-p Please merge this PR into your PR #497, it will be automatically updated. You then have `SiblingContainer` with all necessary methods in the public interface and can proceed. I had originally thought to overhaul `SiblingContainer` more thoroughly, but have since started to wonder if we need it at all, see #512.
